### PR TITLE
docs: Fix simple typo, intialize -> initialize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Installation Procedure
        '..................'
     ]
 
-3. Run npm init to intialize npm modules and it will create 'package.json' file which will contain package information. Update file with following dependencies::
+3. Run npm init to initialize npm modules and it will create 'package.json' file which will contain package information. Update file with following dependencies::
 
      "devDependencies": {
         "babel": "^6.23.0",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ Installation Procedure
        '..................'
     ]
 
-3. Run npm init to intialize npm modules and it will create 'package.json' file which will contain package information. Update file with following dependencies::
+3. Run npm init to initialize npm modules and it will create 'package.json' file which will contain package information. Update file with following dependencies::
 
      "devDependencies": {
         "babel": "^6.23.0",


### PR DESCRIPTION
There is a small typo in README.rst, docs/source/index.rst.

Should read `initialize` rather than `intialize`.

